### PR TITLE
[SK-8553] Added deps as changes require re-eval

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
       - uses: fregante/setup-git-user@v1

--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ npm run dev
 ```bash
 npm run build
 ```
+
+## Publishing
+
+This is handled by GitHub actions

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -37,6 +37,7 @@ export const FlagrContextProvider = ({
   useEffect(() => {
     (async () => {
       setValue({
+        ...value,
         loaded: false,
       });
 

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -36,6 +36,10 @@ export const FlagrContextProvider = ({
 
   useEffect(() => {
     (async () => {
+      setValue({
+        loaded: false,
+      });
+
       const Evaluator = createEvaluator({
         flagrUrl,
       });
@@ -56,7 +60,7 @@ export const FlagrContextProvider = ({
         loaded: true,
       });
     })();
-  }, []);
+  }, [id, tags, context, flagrUrl]);
 
   return (
     <FlagrContext.Provider value={value}>{children}</FlagrContext.Provider>


### PR DESCRIPTION
Added dependencies to useEffect as certain properties may be available later in the setup cycle, and require a re-evaluation 

In our particular case (ATM), the Segment anonymous user ID is only available when the Segment library has loaded, however due to its async loading nature, it won't always be available on initial render cycle of Context Provider.'

Other prime examples would be information within the `context` not being available until an API request has completed